### PR TITLE
feat(mcp): add MCP server for read-only portfolio access

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python -m gunicorn --chdir src wsgi --log-file -
+web: python -m uvicorn --app-dir src Portfolio.asgi:application --host 0.0.0.0 --port ${PORT:-8000}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@ Django==5.2.7
 django-environ==0.12.0
 django-storages==1.14
 flake8==6.1.0
-gunicorn==21.2.0
 importlib-metadata==6.8.0
+mcp==1.27.1
 jmespath==1.0.1
 Markdown==3.4.4
 mccabe==0.7.0
@@ -31,6 +31,7 @@ sqlparse==0.4.4
 tomli==2.0.1
 typing_extensions==4.8.0
 urllib3==1.26.16
+uvicorn[standard]==0.47.0
 wheel==0.37.0
 whitenoise==6.5.0
 zipp==3.17.0

--- a/src/Portfolio/asgi.py
+++ b/src/Portfolio/asgi.py
@@ -1,10 +1,9 @@
-"""
-ASGI config for Portfolio project.
+"""ASGI config for Portfolio.
 
-It exposes the ASGI callable as a module-level variable named ``application``.
+Composes Django with an MCP server mounted at /mcp. Everything else
+falls through to the regular Django app.
 
-For more information on this file, see
-https://docs.djangoproject.com/en/3.2/howto/deployment/asgi/
+See https://docs.djangoproject.com/en/6.0/howto/deployment/asgi/
 """
 
 import os
@@ -13,4 +12,21 @@ from django.core.asgi import get_asgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'Portfolio.settings')
 
-application = get_asgi_application()
+django_app = get_asgi_application()
+
+from starlette.applications import Starlette
+from starlette.routing import Mount
+
+from mcp_server.auth import BearerAuthMiddleware
+from mcp_server.server import mcp_app
+
+_mcp_route = mcp_app.routes[0]
+_mcp_route.app = BearerAuthMiddleware(_mcp_route.app, os.getenv("MCP_TOKEN"))
+
+application = Starlette(
+    routes=[
+        _mcp_route,
+        Mount("/", app=django_app),
+    ],
+    lifespan=mcp_app.router.lifespan_context,
+)

--- a/src/Portfolio/settings.py
+++ b/src/Portfolio/settings.py
@@ -38,7 +38,7 @@ if DEBUG:
         if _dev_host not in _env_allowed_hosts:
             _env_allowed_hosts.append(_dev_host)
 ALLOWED_HOSTS = _env_allowed_hosts
-CSRF_TRUSTED_ORIGINS = os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",")
+CSRF_TRUSTED_ORIGINS = [o for o in os.getenv("CSRF_TRUSTED_ORIGINS", "").split(",") if o]
 # Application definition
 
 INSTALLED_APPS = [

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -1,0 +1,44 @@
+"""Bearer-token ASGI middleware for the MCP endpoint."""
+
+
+def _extract_bearer(scope) -> str | None:
+    for name, value in scope.get("headers", []):
+        if name == b"authorization":
+            decoded = value.decode("latin-1")
+            if decoded.startswith("Bearer "):
+                return decoded[7:].strip()
+            return None
+    return None
+
+
+async def _send_status(send, status: int, message: bytes, extra_headers=()) -> None:
+    headers = [(b"content-type", b"text/plain; charset=utf-8")]
+    headers.extend(extra_headers)
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": message})
+
+
+class BearerAuthMiddleware:
+    def __init__(self, app, expected_token: str | None) -> None:
+        self.app = app
+        self.expected_token = expected_token
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if not self.expected_token:
+            await _send_status(send, 503, b"MCP_TOKEN is not configured on the server.\n")
+            return
+
+        if _extract_bearer(scope) != self.expected_token:
+            await _send_status(
+                send,
+                401,
+                b"Unauthorized\n",
+                extra_headers=[(b"www-authenticate", b'Bearer realm="mcp"')],
+            )
+            return
+
+        await self.app(scope, receive, send)

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,0 +1,64 @@
+"""MCP server exposing read-only access to the portfolio Project model.
+
+Mounted under /mcp by Portfolio.asgi via Starlette routing.
+"""
+from asgiref.sync import sync_to_async
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("portfolio", stateless_http=True)
+
+
+def _project_to_dict(project, include_description: bool) -> dict:
+    image_url = None
+    try:
+        if project.image:
+            image_url = project.image.url
+    except ValueError:
+        image_url = None
+
+    data = {
+        "id": project.id,
+        "title": project.title,
+        "type": project.type,
+        "link": project.link,
+        "github_link": project.github_link,
+        "image_url": image_url,
+    }
+    if include_description:
+        data["description"] = project.description
+    return data
+
+
+@mcp.tool()
+async def list_projects() -> list[dict]:
+    """List every portfolio project with summary fields (no description body)."""
+    from homepage.models import Project
+
+    def _fetch():
+        return [
+            _project_to_dict(p, include_description=False)
+            for p in Project.objects.all().order_by("-id")
+        ]
+
+    return await sync_to_async(_fetch)()
+
+
+@mcp.tool()
+async def get_project(project_id: int) -> dict:
+    """Get full details for one project by its database id, including the raw markdown description."""
+    from homepage.models import Project
+
+    def _fetch():
+        try:
+            project = Project.objects.get(pk=project_id)
+        except Project.DoesNotExist:
+            return None
+        return _project_to_dict(project, include_description=True)
+
+    result = await sync_to_async(_fetch)()
+    if result is None:
+        raise ValueError(f"Project {project_id} not found")
+    return result
+
+
+mcp_app = mcp.streamable_http_app()


### PR DESCRIPTION
Adds an MCP (Model Context Protocol) HTTP server mounted at /mcp, exposing two read-only tools so Claude (Desktop, Code, or any MCP client) can browse portfolio projects:

- list_projects: summary fields for every Project, ordered newest-first
- get_project(project_id): full record including raw markdown description

Architecture:
- New module src/mcp_server/ holds the FastMCP server (stateless_http mode) and a bearer-token ASGI middleware.
- src/Portfolio/asgi.py composes Django + FastMCP behind one Starlette router: /mcp -> auth-gated FastMCP, everything else -> Django. FastMCP's lifespan_context drives the outer app so its session manager starts and stops cleanly.

Deployment changes:
- Procfile switched from gunicorn (WSGI) to uvicorn (ASGI) since MCP needs streaming HTTP. The previous Procfile pointed at src/wsgi.py which still exists; switching cleanly to Portfolio.asgi:application.
- requirements.txt: add mcp==1.27.1 and uvicorn[standard]==0.47.0, drop gunicorn.

Operational notes:
- Bearer auth via MCP_TOKEN env var. Server returns 503 if unset, 401 on missing/wrong token, so misconfiguration fails closed.
- Stateless HTTP mode means each request stands alone; safe behind any number of dynos.
- Empty CSRF_TRUSTED_ORIGINS fix included so the system check doesn't block migrate on a fresh env (same change as in the Django-bump PR; pulled in here to keep this branch self-contained).

Verified locally end-to-end against uvicorn with a real MCP client: initialize, tools/list, list_projects, get_project (hit and miss).