### PR TITLE
feat(mcp): add CRUD tools and document MCP server

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,0 +1,181 @@
+# MCP Server
+
+## Overview
+
+The portfolio ships an embedded [Model Context Protocol](https://modelcontextprotocol.io) server that exposes CRUD access to the `Project` model. It lets MCP-capable LLM clients (Claude Desktop, Claude Code, the MCP Inspector, etc.) browse and modify the projects in your portfolio as a structured data source instead of scraping the rendered HTML.
+
+The server lives in [`src/mcp_server/`](../src/mcp_server) and is mounted into the ASGI app at the path **`/mcp`** (no trailing slash — that's what FastMCP's `streamable_http_app()` registers by default).
+
+## Architecture
+
+The Django app and the MCP server are composed at the ASGI layer using Starlette as the outer router:
+
+```
+        ┌──────────────────────────────────────────────┐
+        │  Starlette (Portfolio.asgi:application)      │
+        │                                              │
+        │   /mcp   ──►  BearerAuthMiddleware           │
+        │                    └─►  FastMCP streamable   │
+        │                              HTTP app        │
+        │                                              │
+        │   /      ──►  Django (get_asgi_application)  │
+        └──────────────────────────────────────────────┘
+```
+
+Wired in [`src/Portfolio/asgi.py`](../src/Portfolio/asgi.py):
+
+- `mcp_server.server.mcp_app` is a FastMCP `streamable_http_app()` — a Starlette sub-app speaking JSON-RPC 2.0 over the [streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http).
+- The single route inside `mcp_app` is wrapped in `BearerAuthMiddleware` so every request to `/mcp` must present a valid bearer token before it reaches the JSON-RPC handler.
+- Everything else falls through to the regular Django WSGI/ASGI app mounted at `/`.
+
+Because the entrypoint is ASGI, the app is started with `uvicorn` (see [`Procfile`](../Procfile)), not `gunicorn`. The `python manage.py runserver` dev command works for the Django side but does **not** serve the `/mcp` route — for end-to-end MCP testing you need to run uvicorn directly (see [Local testing](#local-testing) below).
+
+## Exposed tools
+
+Defined in [`src/mcp_server/server.py`](../src/mcp_server/server.py) using the FastMCP `@mcp.tool()` decorator. The server is initialised as `FastMCP("portfolio", stateless_http=True)` — `stateless_http=True` means each HTTP request is a self-contained JSON-RPC call with no server-side session.
+
+| Tool | Args | Returns | Description |
+|---|---|---|---|
+| `list_projects` | none | `list[dict]` | Every `Project` row ordered newest-first. Summary fields only — `description` is omitted to keep responses small. |
+| `get_project` | `project_id: int` | `dict` | Full details for one project including the raw markdown `description`. Raises `ValueError` if no project has that id. |
+| `create_project` | `title: str`, optional `type`, `link`, `github_link`, `description` | `dict` | Creates a new project and returns its full details (including the assigned `id`). Image upload is **not** supported via MCP — the project is created without an image (`image_url` will be `null`). |
+| `update_project` | `project_id: int`, optional `title`, `type`, `link`, `github_link`, `description` | `dict` | Partial update — only fields explicitly passed (non-null) are written; everything else is left untouched. Raises `ValueError` if no project has that id. |
+| `delete_project` | `project_id: int` | `dict` | Deletes the project. Returns `{"deleted": true, "id": ..., "title": ...}` for confirmation. Raises `ValueError` if no project has that id. |
+
+All tools wrap synchronous ORM calls in `asgiref.sync.sync_to_async` so they don't block the event loop.
+
+### A note on images
+
+Adding an image to a project requires uploading a file, which doesn't fit the JSON-RPC request shape cleanly. The MCP tools deliberately don't expose image upload — projects created via MCP have no image until you add one through the Django admin or a separate workflow. The existing [`create_test_projects` management command](CREATE_TEST_PROJECTS.md) shows the pattern for adding images programmatically (downloads from Picsum, attaches via `project.image.save(...)`).
+
+### Project dict shape
+
+```python
+{
+    "id": int,
+    "title": str,
+    "type": str,
+    "link": str | None,
+    "github_link": str | None,
+    "image_url": str | None,   # signed S3 URL if AWS storage is configured, else local path
+    "description": str,        # only present from get_project
+}
+```
+
+`image_url` is `None` when the project has no image *or* when accessing `project.image.url` raises `ValueError` (e.g. the file is missing from storage).
+
+## Authentication
+
+`/mcp` is protected by [`BearerAuthMiddleware`](../src/mcp_server/auth.py). Every request must include:
+
+```
+Authorization: Bearer <token>
+```
+
+The expected token is read from the `MCP_TOKEN` environment variable at startup.
+
+| Condition | Response |
+|---|---|
+| `MCP_TOKEN` env var is unset or empty | `503 Service Unavailable` with body `MCP_TOKEN is not configured on the server.` |
+| `Authorization` header missing or token mismatch | `401 Unauthorized` with `WWW-Authenticate: Bearer realm="mcp"` |
+| Token matches | Request is forwarded to the FastMCP app |
+
+The middleware only enforces auth on `scope["type"] == "http"`. Non-HTTP scopes (lifespan startup/shutdown events) pass through unchanged.
+
+## Configuration
+
+Add one new environment variable to your `.env` and to the deployment environment:
+
+```bash
+# A long random string. Rotate by re-generating and updating both the
+# server and every connected MCP client.
+MCP_TOKEN=replace-with-a-long-random-string
+```
+
+Suggested generation:
+
+```bash
+python -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+> **Heroku note:** at the time of writing, `MCP_TOKEN` is **not** set on the `lamonkey-portfolio` Heroku app. Until it is, requests to `https://lamonkey-portfolio.herokuapp.com/mcp` will return `503`. Set it with:
+>
+> ```bash
+> heroku config:set MCP_TOKEN="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')" -a lamonkey-portfolio
+> ```
+
+## Local testing
+
+The MCP route is only mounted when the app runs through ASGI (uvicorn), not through `manage.py runserver`. Start it the way the Procfile does:
+
+```bash
+export MCP_TOKEN=dev-token-change-me
+.venv/bin/python -m uvicorn --app-dir src Portfolio.asgi:application --host 127.0.0.1 --port 8000
+```
+
+### Smoke test with curl
+
+The streamable-HTTP transport speaks JSON-RPC 2.0. A minimal `tools/list` round-trip:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8000/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+Calling `list_projects`:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8000/mcp \
+  -H "Authorization: Bearer $MCP_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_projects","arguments":{}}}'
+```
+
+In practice, most flows go through the [MCP Inspector](https://github.com/modelcontextprotocol/inspector) or a client like Claude Desktop rather than raw curl — those handle the `initialize` handshake and capability negotiation for you.
+
+### Inspector
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+In the UI, choose the **Streamable HTTP** transport, point it at `http://127.0.0.1:8000/mcp`, and add the `Authorization: Bearer ...` header. You should see `list_projects` and `get_project` show up in the tool list.
+
+### Claude Desktop / Claude Code
+
+Add an entry to your client's MCP config (`~/Library/Application Support/Claude/claude_desktop_config.json` for Claude Desktop):
+
+```json
+{
+  "mcpServers": {
+    "portfolio": {
+      "url": "https://lamonkey-portfolio.herokuapp.com/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_MCP_TOKEN_HERE"
+      }
+    }
+  }
+}
+```
+
+Restart the client. The two tools should appear under the `portfolio` server.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [`src/mcp_server/server.py`](../src/mcp_server/server.py) | FastMCP app + tool definitions. |
+| [`src/mcp_server/auth.py`](../src/mcp_server/auth.py) | Bearer-token ASGI middleware. |
+| [`src/mcp_server/__init__.py`](../src/mcp_server/__init__.py) | Empty — marks the package. |
+| [`src/Portfolio/asgi.py`](../src/Portfolio/asgi.py) | Composes Django + MCP under one Starlette router. |
+| [`Procfile`](../Procfile) | Uses uvicorn so the ASGI composition is actually served. |
+
+## Extending the server
+
+To add a new tool, add another `@mcp.tool()`-decorated `async def` in `server.py`. The function's name becomes the tool name, its docstring becomes the tool description shown to the LLM, and its type annotations are turned into the JSON Schema for arguments and return value. Keep ORM access inside a synchronous helper wrapped in `sync_to_async` so the event loop stays unblocked.
+
+For resources or prompts (the other MCP primitives), use `@mcp.resource()` and `@mcp.prompt()` from FastMCP respectively — currently neither is used by the portfolio server.

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -1,7 +1,9 @@
-"""MCP server exposing read-only access to the portfolio Project model.
+"""MCP server exposing CRUD access to the portfolio Project model.
 
 Mounted under /mcp by Portfolio.asgi via Starlette routing.
 """
+from typing import Optional
+
 from asgiref.sync import sync_to_async
 from mcp.server.fastmcp import FastMCP
 
@@ -59,6 +61,86 @@ async def get_project(project_id: int) -> dict:
     if result is None:
         raise ValueError(f"Project {project_id} not found")
     return result
+
+
+@mcp.tool()
+async def create_project(
+    title: str,
+    type: str = "",
+    link: Optional[str] = None,
+    github_link: Optional[str] = None,
+    description: Optional[str] = None,
+) -> dict:
+    """Create a new portfolio project. Image upload is not supported via MCP; the project is created without an image."""
+    from homepage.models import Project
+
+    def _create():
+        project = Project.objects.create(
+            title=title,
+            type=type,
+            link=link,
+            github_link=github_link,
+            description=description,
+        )
+        return _project_to_dict(project, include_description=True)
+
+    return await sync_to_async(_create)()
+
+
+@mcp.tool()
+async def update_project(
+    project_id: int,
+    title: Optional[str] = None,
+    type: Optional[str] = None,
+    link: Optional[str] = None,
+    github_link: Optional[str] = None,
+    description: Optional[str] = None,
+) -> dict:
+    """Partial-update an existing project. Only fields explicitly passed (non-null) are written."""
+    from homepage.models import Project
+
+    def _update():
+        try:
+            project = Project.objects.get(pk=project_id)
+        except Project.DoesNotExist:
+            return None
+        if title is not None:
+            project.title = title
+        if type is not None:
+            project.type = type
+        if link is not None:
+            project.link = link
+        if github_link is not None:
+            project.github_link = github_link
+        if description is not None:
+            project.description = description
+        project.save()
+        return _project_to_dict(project, include_description=True)
+
+    result = await sync_to_async(_update)()
+    if result is None:
+        raise ValueError(f"Project {project_id} not found")
+    return result
+
+
+@mcp.tool()
+async def delete_project(project_id: int) -> dict:
+    """Delete a project by id. Returns the deleted project's id and title for confirmation."""
+    from homepage.models import Project
+
+    def _delete():
+        try:
+            project = Project.objects.get(pk=project_id)
+        except Project.DoesNotExist:
+            return None
+        snapshot = {"id": project.id, "title": project.title}
+        project.delete()
+        return snapshot
+
+    result = await sync_to_async(_delete)()
+    if result is None:
+        raise ValueError(f"Project {project_id} not found")
+    return {"deleted": True, **result}
 
 
 mcp_app = mcp.streamable_http_app()


### PR DESCRIPTION
## Summary

- Extends the embedded MCP server from read-only to full CRUD over the `Project` model — adds `create_project`, `update_project` (partial update; only writes fields explicitly passed), and `delete_project` tools alongside the existing `list_projects` / `get_project`.
- Image upload is intentionally not exposed via MCP (file uploads don't fit JSON-RPC cleanly). Projects created via MCP have no image until one is added through the admin or the existing `create_test_projects` management command.
- Adds `docs/MCP_SERVER.md` covering the ASGI composition with Starlette, the `BearerAuthMiddleware`, all five tools, why `manage.py runserver` does not serve `/mcp` (it's WSGI-only — only uvicorn against `Portfolio.asgi:application` exposes the route), local-testing curl recipes, and client wiring for the MCP Inspector and Claude Desktop.

## Test plan

- [x] `tools/list` advertises all five tools with auto-generated JSON schemas
- [x] `create_project` → returns assigned id, persists to DB
- [x] `update_project` partial update — passing only `title` + `description` leaves `type`, `link`, `github_link` untouched
- [x] `delete_project` removes the row; subsequent `get_project` returns `isError: true` with `"Project N not found"`
- [x] Bearer-token auth still enforced (401 without token, 200 with)
- [x] Sanity-checked row count via Django shell before and after the full add → edit → delete cycle
- [ ] Verify `MCP_TOKEN` is set on Heroku before relying on production `/mcp` (currently unset — production endpoint will return 503 until configured)

## Notes for reviewer

- `runserver` still won't serve `/mcp` — that's by design (the MCP route only exists in `Portfolio/asgi.py`, not Django's URL conf). The doc explains the trade-off.
- The route is `/mcp` with **no** trailing slash — that's the FastMCP `streamable_http_app()` default. Earlier internal docs/curl examples used `/mcp/` by mistake; this PR corrects them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)