### PR TITLE
feat(nav): cross-link projects ↔ blog in page footers

### DIFF
--- a/src/homepage/templates/homepage/blog_list.html
+++ b/src/homepage/templates/homepage/blog_list.html
@@ -58,7 +58,9 @@
 
       <footer class="log-footer">
         <p>
-          Made by Jesse Chen · For longer-form essays see
+          Made by Jesse Chen · See the
+          <a href="{% url 'homepage:software-log' %}">projects</a>
+          or longer essays on
           <a href="https://medium.com/@jchen42" target="_blank" rel="noopener noreferrer">Medium</a>.
         </p>
       </footer>

--- a/src/homepage/templates/homepage/software_log.html
+++ b/src/homepage/templates/homepage/software_log.html
@@ -80,7 +80,12 @@
       </main>
 
       <footer class="log-footer">
-        <p>Made by Jesse Chen · Powered by Django templates.</p>
+        <p>
+          Made by Jesse Chen · Read the
+          <a href="{% url 'homepage:blog-list' %}">blog</a>
+          or follow longer essays on
+          <a href="https://medium.com/@jchen42" target="_blank" rel="noopener noreferrer">Medium</a>.
+        </p>
       </footer>
     </div>
   </body>


### PR DESCRIPTION
## Summary

Visitors arriving at jchen42.com (/software-log/) currently have no way to discover the new /blog/ — there's no top-level nav. This adds a one-line footer link from each list page to the other, alongside the existing Medium link for longer essays.

Two-line change in two templates. No CSS, no JS, no model touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)