### PR TITLE
fix(security): fail loudly when SECRET_KEY is unset in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       - DATABASE_URL=postgresql://portfolio_user:portfolio_password@db:5432/portfolio_db
       - MODE=development
       - DEBUG=True
-      - SECRET_KEY=${SECRET_KEY:-django-insecure-test-key-change-in-production}
+      - SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set in .env}
       - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost,127.0.0.1,0.0.0.0}
     depends_on:
       db:


### PR DESCRIPTION
## What

Replaces the silent insecure `SECRET_KEY` fallback in `docker-compose.yml` with a required-variable form that aborts if the value is missing.

```diff
- SECRET_KEY=${SECRET_KEY:-django-insecure-test-key-change-in-production}
+ SECRET_KEY=${SECRET_KEY:?SECRET_KEY must be set in .env}
```

## Why

The old `:-default` form is **fail-open**: if `SECRET_KEY` is unset (fresh clone, CI, missing `.env`), the container silently boots on a hardcoded key that is committed in this **public** repo. Django's `SECRET_KEY` signs session cookies, admin login, and password-reset tokens — a publicly-known value means those can be forged. Compose's `environment:` block also overrides `env_file:`, so the bad default can shadow a real key without any warning.

The `:?` form makes Compose **fail with a clear error** when the variable is missing — fail-closed, never boots on a known-bad key.

Scope is the dev compose only (`MODE=development`), but it's a footgun worth removing before it gets copied into a prod config.

## Context

Part of the security remediation in #29 (item 4). The exposed AWS keys (item 1) and Django `SECRET_KEY` (item 2) have already been rotated and verified live.

Refs #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)