### PR TITLE
ci: add Dependabot version updates + minimal CI gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      # bump the boto3 family together — botocore caps urllib3, so they must move in lockstep
+      aws:
+        patterns: ["boto3", "botocore", "s3transfer"]
+      # dev-only tooling: low risk, batch into one PR to cut noise
+      dev-tools:
+        patterns: ["flake8", "mypy*", "pycodestyle", "pyflakes", "mccabe"]
+    # stay on the Django 5.2 LTS line; 6.x is a manual migration, not a pin bump
+    ignore:
+      - dependency-name: "Django"
+        update-types: ["version-update:semver-major"]
+
+  # keep the GitHub Actions workflow below up to date too
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      # dummy values so settings.py imports cleanly; never used to serve traffic
+      SECRET_KEY: ci-not-a-real-secret
+      DATABASE_URL: sqlite:///db.sqlite3
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Verify dependency resolution
+        run: pip check
+
+      - name: Django system checks
+        run: python src/manage.py check
+
+      - name: Detect missing migrations
+        run: python src/manage.py makemigrations --check --dry-run
+
+      - name: Run test suite
+        run: python src/manage.py test


### PR DESCRIPTION
Follow-up to #35. Adds the proactive half of dependency hygiene so pins don't silently rot between CVE disclosures.

**`.github/dependabot.yml`** — weekly version-update PRs for pip + GitHub Actions.
- Groups `boto3`/`botocore`/`s3transfer` into one PR (botocore caps urllib3, so they must move together — the exact constraint that complicated #35).
- Groups dev tooling (`flake8`, `mypy`, etc.) to cut noise.
- Ignores Django **major** bumps to stay on the 5.2 LTS line (6.x is a manual migration).

**`.github/workflows/ci.yml`** — runs on every PR + push to master so those Dependabot PRs are actually verified before merge (green = checked, not green = unchecked):
- `pip install -r requirements.txt` + `pip check` (dependency resolution)
- `manage.py check` (system checks)
- `makemigrations --check --dry-run` (migration drift)
- `manage.py test`
- Python 3.12 to match `runtime.txt`; dummy `SECRET_KEY`/`DATABASE_URL` so `settings.py` imports cleanly.

Note: the test suite is currently empty, so the test step is a placeholder that passes — the real value today is the resolve/check/migration gates. Worth fleshing out `tests.py` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)