### PR TITLE
deploy: run migrations via Heroku release phase

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: python src/manage.py migrate --noinput
 web: python -m uvicorn --app-dir src Portfolio.asgi:application --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
The landing-page migrations (`0005`/`0006`) are already on master (#48), but nothing runs `migrate` on deploy — so those tables may not exist on the running dyno.

This adds a Heroku **release phase** command so every deploy applies pending migrations automatically before the new release goes live:

```
release: python src/manage.py migrate --noinput
```

Pairs naturally with the auto-deploy-on-green-CI that was just enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)